### PR TITLE
Make comparisons against all sets unordered.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.0 - 2016-02-02
+~~~~~~~~~~~~~~~~
+
+* breaking change: All comparisons, other than `eq`, against other ordered sets
+  are now performed unordered; i.e., they are treated as regular sets.
+* `isorderedsubset` and `isorderedsuperset` have been added to perform ordered
+  comparisons against other sequences. Using these methods with unordered
+  collections wield yield arbitrary (and depending on Python implementation,
+  unstable) results.
+
 1.2 - 2015-09-29
 ~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,5 +21,3 @@ Indices and tables
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,9 +4,5 @@ Installation
 
 At the command line::
 
-    $ easy_install orderedset
-
-Or, if you have virtualenvwrapper installed::
-
-    $ mkvirtualenv orderedset
     $ pip install orderedset
+

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,35 @@
 Usage
 =====
 
-To use Ordered Set in a project::
+To use OrderedSet in a project::
 
     from orderedset import OrderedSet
 
+    oset = OrderedSet([1, 2, 3])
+    oset2 = OrderedSet([3, 2, 1])
+    oset3 = OrderedSet([1, 2, 3, 4])
+
+    oset == oset2  # False
+    oset <= oset2  # True, same as issubset
+
+
+OrderedSet normally compares like a set, but can be made to make
+ordered sub-/superset comparisons::
+
+    oset.isorderedsubset(oset2)  # False
+    oset.isorderedsubset(oset3)  # True
+
+
+OrderedSets work with other sets, and with lists::
+
+    from orderedset import OrderedSet
+
+    oset = OrderedSet([1, 2, 3])
+    lst = [1, 2, 3]
+    tes = {1, 2, 3}
+
+    oset <= lst  # True
+    oset <= tes  # True
+
+    oset | lst  # OrderedSet([1, 2, 3])
+    oset | tes  # OrderedSet([1, 2, 3])

--- a/lib/orderedset/__init__.py
+++ b/lib/orderedset/__init__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-__version__ = '1.2'
+__version__ = '2.0'
 
 
 from ._orderedset import OrderedSet

--- a/tests/test_orderedset.py
+++ b/tests/test_orderedset.py
@@ -159,6 +159,10 @@ class TestOrderedset(unittest.TestCase):
         self.assertFalse(oset2.issubset(oset1))
         self.assertTrue(oset1 < oset2)
 
+        # issubset compares underordered for all sets
+        oset2 = OrderedSet([4, 3, 2, 1])
+        self.assertTrue(oset1 < oset2)
+
     def test_issuperset(self):
         oset1 = OrderedSet([1, 2, 3])
         oset2 = OrderedSet([1, 2])
@@ -175,6 +179,28 @@ class TestOrderedset(unittest.TestCase):
         self.assertFalse(oset1 > oset2)
         self.assertFalse(oset1.issuperset(oset2))
         self.assertTrue(oset2 > oset1)
+
+        # issubset compares underordered for all sets
+        oset2 = OrderedSet([4, 3, 2, 1])
+        self.assertTrue(oset2 > oset1)
+
+    def test_orderedsubset(self):
+        oset1 = OrderedSet([1, 2, 3])
+        oset2 = OrderedSet([1, 2, 3, 4])
+        oset3 = OrderedSet([1, 2, 4, 3])
+
+        self.assertTrue(oset1.isorderedsubset(oset2))
+        self.assertFalse(oset1.isorderedsubset(oset3))
+        self.assertFalse(oset2.isorderedsubset(oset3))
+
+    def test_orderedsuperset(self):
+        oset1 = OrderedSet([1, 2, 3])
+        oset2 = OrderedSet([1, 2, 3, 4])
+        oset3 = OrderedSet([1, 2, 4, 3])
+
+        self.assertTrue(oset2.isorderedsuperset(oset1))
+        self.assertFalse(oset3.isorderedsuperset(oset1))
+        self.assertFalse(oset3.isorderedsuperset(oset2))
 
     def test_symmetric_difference_and_update(self):
         oset1 = OrderedSet([1, 2, 3])


### PR DESCRIPTION
This is a breaking change. Comparisons against other OrderedSets are now
performed unordered, except for equality checks.

Two new methods have been added to perform ordered comparisons.

Fixes #8 