### PR TITLE
Let `isdisjoint` return `True` when the sets are disjoint

### DIFF
--- a/lib/orderedset/_orderedset.pyx
+++ b/lib/orderedset/_orderedset.pyx
@@ -268,6 +268,7 @@ cdef class _OrderedSet(object):
         for value in other:
             if value in self:
                 return False
+        return True
 
     def issubset(self, other):
         """``OrderedSet <= other``

--- a/tests/test_orderedset.py
+++ b/tests/test_orderedset.py
@@ -275,6 +275,11 @@ class TestOrderedset(unittest.TestCase):
         self.assertEqual(OrderedSet([1, 2, 3, 4]) - [3, 2], OrderedSet([1, 4]))
         self.assertEqual([3, 2, 4, 1] - OrderedSet([2, 4]), OrderedSet([3, 1]))
 
+    def test_isdisjoint(self):
+        self.assertTrue(OrderedSet().isdisjoint(OrderedSet()))
+        self.assertTrue(OrderedSet([1]).isdisjoint(OrderedSet([2])))
+        self.assertFalse(OrderedSet([1, 2]).isdisjoint(OrderedSet([2, 3])))
+
     def test_index(self):
         oset = OrderedSet("abcd")
         self.assertEqual(oset.index("b"), 1)


### PR DESCRIPTION
Fix bug where `isdisjoint` only returned `False` for non-disjoint set,
never `True` for actually disjoint sets.

Fixes #14 